### PR TITLE
Add E2EE encryption method 8 (SJCL4) compatibility for Joplin Desktop >= 2.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@
 
 # Build and install Joplin CLI into a first image
 # Set build arguments to specify particular versions of node and Joplin
-ARG NODE_VERSION=lts
+# NOTE: Joplin CLI >= 3.0 is required for encryption method 8 (SJCL4) support
+# which is used by Joplin Desktop >= 2.14 for E2EE
+ARG NODE_VERSION=20
 ARG JOPLIN_VERSION=latest
 FROM node:${NODE_VERSION}-bookworm-slim as base
 


### PR DESCRIPTION
## Summary

- Add support for E2EE encryption method 8 (SJCL4) used by Joplin Desktop >= 2.14
- Update default NODE_VERSION from `lts` to `20` for consistency and compatibility

## Problem

Joplin Desktop versions >= 2.14 use encryption method 8 (SJCL4) for End-to-End Encryption. The pre-built images using Joplin CLI 2.x cannot decrypt notes encrypted with this method, resulting
in:


Error: Unknown decryption method: 8


This causes all encrypted notes to remain inaccessible (empty titles/content) even when the correct master password is configured.

## Solution

- Joplin CLI >= 3.0 supports encryption method 8
- Updated Dockerfile to default to Node 20 and added compatibility comments
- Updated README with:
  - New "Important: E2EE Compatibility" section explaining the issue
  - Updated examples to recommend building with `JOPLIN_VERSION=latest`
  - Docker Compose build args example

## Testing

Built and tested with Joplin CLI 3.5.1 against an S3 sync target with E2EE enabled (encryption method 8). Notes sync and decrypt successfully.

---